### PR TITLE
Fix rinadelph__agent-mcp server configuration to use uv command

### DIFF
--- a/app/app/mcp-catalog/data/mcp-evaluations/rinadelph__agent-mcp.json
+++ b/app/app/mcp-catalog/data/mcp-evaluations/rinadelph__agent-mcp.json
@@ -8,8 +8,8 @@
     "name": "rinadelph"
   },
   "server": {
-    "command": "python",
-    "args": ["-m", "agent_mcp.cli", "--project-dir", "${user_config.project_dir}"],
+    "command": "uv",
+    "args": ["run", "-m", "agent_mcp.cli", "--project-dir", "${user_config.project_dir}"],
     "env": {
       "OPENAI_API_KEY": "${user_config.openai_api_key}"
     }


### PR DESCRIPTION

## Summary

Fixed the server command configuration for the `rinadelph__agent-mcp` MCP server to use the correct `uv` command instead of direct `python` invocation. This resolves the installation issue that prevented the MCP server from running properly in the Archestra desktop application.

## Problem

The current configuration was using:
```json
"server": {
  "command": "python",
  "args": ["-m", "agent_mcp.cli", "--project-dir", "${user_config.project_dir}"]
}
```

This command fails because Agent-MCP requires `uv` (Python package manager) to properly manage its virtual environment and dependencies.

## Solution

Updated the configuration to use the correct command:
```json
"server": {
  "command": "uv",
  "args": ["run", "-m", "agent_mcp.cli", "--project-dir", "${user_config.project_dir}"]
}
```


## Testing & Validation


https://github.com/user-attachments/assets/2dd2f468-2987-479a-bb0a-d70e9ba3cac5



### ✅ Documentation Compliance
The fix matches the official Agent-MCP documentation:
- [Installation Guide](https://github.com/rinadelph/Agent-MCP#quick-start) specifies `uv run -m agent_mcp.cli`
- [MCP Integration Guide](https://github.com/rinadelph/Agent-MCP#mcp-integration-guide) shows `uv` usage
- [Claude Desktop Config example](https://github.com/rinadelph/Agent-MCP#using-agent-mcp-with-claude-desktop) uses `uv`

/claim https://github.com/archestra-ai/archestra/issues/304
Fixes https://github.com/archestra-ai/archestra/issues/304