### PR TITLE
fix: remove filesystem server's default config

### DIFF
--- a/app/app/mcp-catalog/data/mcp-evaluations/modelcontextprotocol__servers__src__filesystem.json
+++ b/app/app/mcp-catalog/data/mcp-evaluations/modelcontextprotocol__servers__src__filesystem.json
@@ -20,8 +20,7 @@
       "title": "Allowed Directories",
       "description": "Select directories the filesystem server can access. The server requires at least one allowed directory to operate.",
       "multiple": true,
-      "required": true,
-      "default": ["${HOME}/Desktop", "${HOME}/Documents"]
+      "required": true
     },
     "read_only": {
       "type": "boolean",


### PR DESCRIPTION
If you try to install this MCP server /w the current default value you'll get something along the lines of:

```bash
09:22:42.901 › Container stderr: Error accessing directory /home/mcp/Desktop: Error: ENOENT: no such file or directory, stat '/home/mcp/Desktop'
    at async Object.stat (node:internal/fs/promises:1036:18)
    at async file:///home/mcp/.npm/_npx/a3241bba59c344f5/node_modules/@modelcontextprotocol/server-filesystem/dist/index.js:43:23
    at async Promise.all (index 0)
    at async file:///home/mcp/.npm/_npx/a3241bba59c344f5/node_modules/@modelcontextprotocol/server-filesystem/dist/index.js:41:1 {
  errno: -2,
  code: 'ENOENT',
  syscall: 'stat',
  path: '/home/mcp/Desktop'
}
```

Removing it forces the user to have to select a directory(s) (can't install without specifying a value here):

<img width="550" height="435" alt="Screenshot 2025-09-23 at 9 29 17 AM" src="https://github.com/user-attachments/assets/c87f7ba1-eb1b-477e-997e-4407735f32b3" />
