### PR TITLE
Update protocol features in thingsboard MCP JSON

### DIFF
--- a/app/app/mcp-catalog/data/mcp-evaluations/thingsboard__thingsboard-mcp.json
+++ b/app/app/mcp-catalog/data/mcp-evaluations/thingsboard__thingsboard-mcp.json
@@ -36,14 +36,14 @@
     "latest_commit_hash": "adac2d247c408487ef1f99ebb65f8889792dc632"
   },
   "protocol_features": {
-    "implementing_tools": false,
+    "implementing_tools": true,
     "implementing_prompts": false,
     "implementing_resources": false,
     "implementing_sampling": false,
     "implementing_roots": false,
     "implementing_logging": false,
-    "implementing_stdio": false,
-    "implementing_streamable_http": false,
+    "implementing_stdio": true,
+    "implementing_streamable_http": true,
     "implementing_oauth2": false
   },
   "dependencies": [


### PR DESCRIPTION
Update protocol features in thingsboard MCP JSON - set 'true' for tools, stdio and streamable_http