### PR TITLE
fix: OpenWebUI docs update

### DIFF
--- a/app/app/docs/content/platform-openwebui-example.md
+++ b/app/app/docs/content/platform-openwebui-example.md
@@ -61,6 +61,8 @@ Once OpenWebUI is running:
 4. Verify that you have a correct OpenAI API Key and BASE_URL of Archestra: [http://localhost:9000/v1/openai](http://localhost:9000/v1/openai) in URL, or Add Connection with those values, if you use your own OpenWebUI
    ☝️If you're not sure where is Archestra BASE_URL you can navigate to Archestra settings, in our example it on [http://localhost:3000](http://localhost:3000)
 
+   ✌️️If you're running OpenWebUI in its own Docker container locally, separately from the platform, the `BASE_URL` will have Docker's special hostname, `host.docker.internal` instead of `localhost`. E.g. `http://host.docker.internal:9000/v1/openai`
+
    **Optional:** To use a specific agent, include the agent ID in the URL: `http://localhost:9000/v1/openai/{agent-id}`. You can create and manage agents at [http://localhost:3000/agents](http://localhost:3000/agents)
 
    ![openwebui](/docs/platfrom/openwebui-image1.png)
@@ -85,10 +87,10 @@ Also you can start using MCP servers
 1. Click **User > Admin Panel**
 2. Navigate to **Settings > External tools > Manage Tool Servers > +**
 3. In the dialog window select **Type: MCP Streamable HTTP**
-4. Paste your mcp server streamable http url and Github Personal Access Token, e.g.
+4. Paste your MCP server streamable HTTP URL. This example uses Dungeons and Dragons MCP, which also requires your GitHub personal access token.
 
-   ```javascript
-   [https://dmcp-server.deno.dev/mcp](https://api.githubcopilot.com/mcp)
+   ```
+   https://dmcp-server.deno.dev/mcp
    ```
 
    ![](/docs/platfrom/openwebui-image3.png)


### PR DESCRIPTION
- In OpenWebUI doc, adds a note about Docker hostname (for the likes of me for whom`host.docker.internal` isn't obvious)
- Removes the ambuguity in MCP example.

Related to https://github.com/archestra-ai/archestra/issues/618
Main PR https://github.com/archestra-ai/archestra/pull/790