### PR TITLE
fix: k8s mcp instructions

### DIFF
--- a/app/app/mcp-catalog/api/docs/openapi.json
+++ b/app/app/mcp-catalog/api/docs/openapi.json
@@ -274,6 +274,9 @@
               "additionalProperties": false
             }
           },
+          "instructions": {
+            "type": "string"
+          },
           "readme": {
             "type": "string",
             "nullable": true

--- a/app/app/mcp-catalog/data/mcp-evaluations/flux159__mcp-server-kubernetes.json
+++ b/app/app/mcp-catalog/data/mcp-evaluations/flux159__mcp-server-kubernetes.json
@@ -1,7 +1,8 @@
 {
   "name": "flux159__mcp-server-kubernetes",
   "display_name": "Kubernetes",
-  "description": "Specify which cluster context to manage (e.g., 'production', 'staging'). It's important specify a context for your application clusters. Leaving this empty will manage the Archestra platform cluster itself.",
+  "description": "MCP Server for kubernetes management commands",
+  "instructions": "All configuration fields are optional. Leave blank to use your current kubectl context. Configure specific settings below only if you need to override the default behavior or enable security modes.",
   "author": {
     "name": "Flux159"
   },

--- a/app/app/mcp-catalog/schemas.ts
+++ b/app/app/mcp-catalog/schemas.ts
@@ -187,6 +187,11 @@ export const ArchestraMcpServerManifestSchema = McpbManifestSchema._def.schema
      * Human-friendly name for UI display
      */
     display_name: z.string(),
+
+    /**
+     * Installation instructions shown in the installation modal
+     */
+    instructions: z.string().optional(),
     readme: z.string().nullable(),
     category: McpServerCategorySchema.nullable(),
     quality_score: z.number().min(0).max(100).nullable(),


### PR DESCRIPTION
Adds `instructions` field