### PR TITLE
fix(docs): correct prev/next navigation

### DIFF
--- a/app/app/docs/utils.test.ts
+++ b/app/app/docs/utils.test.ts
@@ -1,0 +1,99 @@
+import type { DocPage } from './types';
+import { compareDocPages } from './utils';
+
+describe('compareDocPages', () => {
+  it('should sort docs by category order', () => {
+    const archestraDoc: DocPage = {
+      slug: 'archestra',
+      title: 'Archestra',
+      category: 'Archestra Platform',
+      order: 1,
+      content: '',
+      readingTime: '1 min',
+      lastUpdated: '2024-01-01',
+    };
+    const gettingStartedDoc: DocPage = {
+      slug: 'getting-started',
+      title: 'Getting Started',
+      category: 'Getting Started',
+      order: 1,
+      content: '',
+      readingTime: '1 min',
+      lastUpdated: '2024-01-01',
+    };
+
+    expect(compareDocPages(archestraDoc, gettingStartedDoc)).toBeLessThan(0);
+  });
+
+  it('should place docs without subcategory before docs with subcategory', () => {
+    const docWithoutSubcat: DocPage = {
+      slug: 'intro',
+      title: 'Intro',
+      category: 'Getting Started',
+      order: 2,
+      content: '',
+      readingTime: '1 min',
+      lastUpdated: '2024-01-01',
+    };
+    const docWithSubcat: DocPage = {
+      slug: 'auth',
+      title: 'Auth',
+      category: 'Getting Started',
+      subcategory: 'Advanced',
+      order: 1,
+      content: '',
+      readingTime: '1 min',
+      lastUpdated: '2024-01-01',
+    };
+
+    expect(compareDocPages(docWithoutSubcat, docWithSubcat)).toBeLessThan(0);
+  });
+
+  it('should sort alphabetically by subcategory name', () => {
+    const authDoc: DocPage = {
+      slug: 'auth',
+      title: 'Auth',
+      category: 'Getting Started',
+      subcategory: 'Authentication',
+      order: 2,
+      content: '',
+      readingTime: '1 min',
+      lastUpdated: '2024-01-01',
+    };
+    const configDoc: DocPage = {
+      slug: 'config',
+      title: 'Config',
+      category: 'Getting Started',
+      subcategory: 'Configuration',
+      order: 1,
+      content: '',
+      readingTime: '1 min',
+      lastUpdated: '2024-01-01',
+    };
+
+    expect(compareDocPages(authDoc, configDoc)).toBeLessThan(0);
+  });
+
+  it('should sort by order field within same category and subcategory', () => {
+    const doc1: DocPage = {
+      slug: 'doc1',
+      title: 'Doc 1',
+      category: 'Getting Started',
+      order: 1,
+      content: '',
+      readingTime: '1 min',
+      lastUpdated: '2024-01-01',
+    };
+    const doc2: DocPage = {
+      slug: 'doc2',
+      title: 'Doc 2',
+      category: 'Getting Started',
+      order: 2,
+      content: '',
+      readingTime: '1 min',
+      lastUpdated: '2024-01-01',
+    };
+
+    expect(compareDocPages(doc1, doc2)).toBeLessThan(0);
+  });
+});

--- a/app/app/docs/utils.ts
+++ b/app/app/docs/utils.ts
@@ -64,27 +64,7 @@ export function getAllDocs(): DocPage[] {
         } as DocPage;
       });
 
-    return allDocsData.sort((a, b) => {
-      // First, sort by category
-      const categoryCompare = getCategoryOrder(a.category) - getCategoryOrder(b.category);
-      if (categoryCompare !== 0) return categoryCompare;
-
-      // Then, docs without subcategory come before docs with subcategory
-      const aHasSubcat = !!a.subcategory;
-      const bHasSubcat = !!b.subcategory;
-      if (aHasSubcat !== bHasSubcat) {
-        return aHasSubcat ? 1 : -1; // Docs without subcategory come first
-      }
-
-      // If both have subcategories, sort by subcategory name first
-      if (aHasSubcat && bHasSubcat) {
-        const subcatCompare = (a.subcategory || '').localeCompare(b.subcategory || '');
-        if (subcatCompare !== 0) return subcatCompare;
-      }
-
-      // Finally, sort by order
-      return a.order - b.order;
-    });
+    return allDocsData.sort(compareDocPages);
   } catch (error) {
     console.error('Error reading documentation:', error);
     return [];
@@ -229,4 +209,26 @@ function getNavigationLinks(currentSlug: string): { prev?: DocNavItem; next?: Do
 function getCategoryOrder(category: string): number {
   const index = categoryOrder.findIndex((cat) => cat.toLowerCase() === category.toLowerCase());
   return index === -1 ? 999 : index;
+}
+
+export function compareDocPages(a: DocPage, b: DocPage): number {
+  // First, sort by category
+  const categoryCompare = getCategoryOrder(a.category) - getCategoryOrder(b.category);
+  if (categoryCompare !== 0) return categoryCompare;
+
+  // Then, docs without subcategory come before docs with subcategory
+  const aHasSubcat = !!a.subcategory;
+  const bHasSubcat = !!b.subcategory;
+  if (aHasSubcat !== bHasSubcat) {
+    return aHasSubcat ? 1 : -1; // Docs without subcategory come first
+  }
+
+  // If both have subcategories, sort by subcategory name first
+  if (aHasSubcat && bHasSubcat) {
+    const subcatCompare = (a.subcategory || '').localeCompare(b.subcategory || '');
+    if (subcatCompare !== 0) return subcatCompare;
+  }
+
+  // Finally, sort by order
+  return a.order - b.order;
 }


### PR DESCRIPTION
Docs navigation now matches sidebar order. Updated sorting to place docs without subcategory before docs with subcategory, then sort by subcategory name alphabetically.

Discussed in slack conversation https://archestracommunity.slack.com/archives/C0975QYN5LZ/p1765542664111999?thread_ts=1765541805.569129&cid=C0975QYN5LZ