### PR TITLE
fix: add Open Graph image to blog post metadata

### DIFF
--- a/app/app/blog/[slug]/page.tsx
+++ b/app/app/blog/[slug]/page.tsx
@@ -37,6 +37,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       type: 'article',
       publishedTime: post.date,
       authors: [post.author],
+      images: post.image ? [{ url: post.image }] : undefined,
     },
   };
 }


### PR DESCRIPTION
Added the blog post's main image to the Open Graph metadata so that social media previews display the correct image instead of the default logo.