### PR TITLE
fix(docs): enable scrolling on TOC sidebar

### DIFF
--- a/app/app/docs/[slug]/page.tsx
+++ b/app/app/docs/[slug]/page.tsx
@@ -152,11 +152,11 @@ export default async function DocPage({ params }: Props) {
                 {/* Table of Contents - Right Sidebar */}
                 <aside className="hidden xl:block w-64 flex-shrink-0">
                   {toc.length > 0 && (
-                    <div className="sticky top-20">
+                    <div className="sticky top-20 max-h-[calc(100vh-6rem)] overflow-y-auto">
                       <h3 className="text-sm font-semibold text-gray-900 mb-4 uppercase tracking-wider">
                         On this page
                       </h3>
-                      <nav className="space-y-1">
+                      <nav className="space-y-1 pb-4">
                         {toc.map((item) => (
                           <a
                             key={item.id}


### PR DESCRIPTION
## Summary
- Add `max-height` and `overflow-y-auto` to the right-hand "On this page" table of contents sidebar
- Users can now scroll through long document navigation lists on pages with many headings

## Test plan
- [ ] Navigate to a docs page with many sections (e.g., `/docs/platform-supported-llm-providers`)
- [ ] Verify the right-hand TOC sidebar can scroll when content exceeds viewport height

🤖 Generated with [Claude Code](https://claude.ai/code)