### PR TITLE
fix: use migrated docs architecture asset

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -79,7 +79,7 @@ export default function Home() {
               {/* Right: Platform Architecture Diagram */}
               <div className="lg:basis-3/5 w-full">
                 <Image
-                  src="/api/docs-images/platform-overview-architecture.png"
+                  src="/api/docs-images/platform-overview-architecture.webp"
                   alt="Archestra Platform Architecture"
                   width={2208}
                   height={1420}

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -276,9 +276,12 @@ export default function Home() {
 
                 {/* Chat UI Screenshot */}
                 <div className="relative rounded-2xl overflow-hidden shadow-2xl border border-gray-200 bg-white">
-                  <img
+                  <Image
                     src="/api/docs-images/chat.webp"
                     alt="Chat Interface"
+                    width={3644}
+                    height={2368}
+                    sizes="(min-width: 1024px) 50vw, 100vw"
                     className="w-full h-auto"
                   />
                 </div>
@@ -542,9 +545,12 @@ export default function Home() {
 
                 {/* Screenshot Container */}
                 <div className="relative rounded-2xl overflow-hidden shadow-2xl border border-gray-200 bg-white">
-                  <img
+                  <Image
                     src="/api/docs-images/mcp-registry.webp"
                     alt="Private MCP Registry Interface"
+                    width={2490}
+                    height={1554}
+                    sizes="(min-width: 1024px) 50vw, 100vw"
                     className="w-full h-auto"
                   />
                 </div>
@@ -811,9 +817,12 @@ export default function Home() {
 
                 {/* Cost Chart Screenshot */}
                 <div className="relative rounded-2xl overflow-hidden shadow-2xl border border-gray-200 bg-white">
-                  <img
+                  <Image
                     src="/api/docs-images/cost.webp"
                     alt="Cost Monitoring Dashboard"
+                    width={2000}
+                    height={1048}
+                    sizes="(min-width: 1024px) 50vw, 100vw"
                     className="w-full h-auto"
                   />
                 </div>
@@ -975,9 +984,12 @@ export default function Home() {
 
                 {/* Observability Dashboard Screenshot */}
                 <div className="relative rounded-2xl overflow-hidden shadow-2xl border border-gray-200 bg-white">
-                  <img
+                  <Image
                     src="/api/docs-images/observability.webp"
                     alt="Observability Dashboard"
+                    width={2920}
+                    height={1488}
+                    sizes="(min-width: 1024px) 50vw, 100vw"
                     className="w-full h-auto"
                   />
                 </div>

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -277,7 +277,7 @@ export default function Home() {
                 {/* Chat UI Screenshot */}
                 <div className="relative rounded-2xl overflow-hidden shadow-2xl border border-gray-200 bg-white">
                   <img
-                    src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/chat.webp"
+                    src="/api/docs-images/chat.webp"
                     alt="Chat Interface"
                     className="w-full h-auto"
                   />
@@ -543,7 +543,7 @@ export default function Home() {
                 {/* Screenshot Container */}
                 <div className="relative rounded-2xl overflow-hidden shadow-2xl border border-gray-200 bg-white">
                   <img
-                    src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/mcp-registry.webp"
+                    src="/api/docs-images/mcp-registry.webp"
                     alt="Private MCP Registry Interface"
                     className="w-full h-auto"
                   />
@@ -812,7 +812,7 @@ export default function Home() {
                 {/* Cost Chart Screenshot */}
                 <div className="relative rounded-2xl overflow-hidden shadow-2xl border border-gray-200 bg-white">
                   <img
-                    src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/cost.webp"
+                    src="/api/docs-images/cost.webp"
                     alt="Cost Monitoring Dashboard"
                     className="w-full h-auto"
                   />
@@ -976,7 +976,7 @@ export default function Home() {
                 {/* Observability Dashboard Screenshot */}
                 <div className="relative rounded-2xl overflow-hidden shadow-2xl border border-gray-200 bg-white">
                   <img
-                    src="https://raw.githubusercontent.com/archestra-ai/archestra/main/docs/assets/observability.webp"
+                    src="/api/docs-images/observability.webp"
                     alt="Observability Dashboard"
                     className="w-full h-auto"
                   />

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -26,7 +26,8 @@ export default function Header() {
               alt={`${companyName} Logo`}
               width={40}
               height={40}
-              className="h-10 w-auto object-contain"
+              className="object-contain"
+              style={{ height: '40px', width: 'auto' }}
             />
             <span className="font-[family-name:var(--font-roboto-mono)] text-2xl text-black hidden lg:inline">
               Archestra.AI

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -26,7 +26,7 @@ export default function Header() {
               alt={`${companyName} Logo`}
               width={40}
               height={40}
-              className="object-contain"
+              className="h-10 w-auto object-contain"
             />
             <span className="font-[family-name:var(--font-roboto-mono)] text-2xl text-black hidden lg:inline">
               Archestra.AI

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -21,14 +21,9 @@ export default function Header() {
       <div className="container flex items-center px-4 md:px-6 justify-between h-16">
         <div className="flex items-center gap-8">
           <Link href="/" className="flex items-center gap-2 hover:opacity-80 transition-opacity">
-            <Image
-              src={websiteUrls.logoRelativeUrl}
-              alt={`${companyName} Logo`}
-              width={40}
-              height={40}
-              className="object-contain"
-              style={{ height: '40px', width: 'auto' }}
-            />
+            <div className="relative h-10 w-10 shrink-0">
+              <Image src={websiteUrls.logoRelativeUrl} alt={`${companyName} Logo`} fill className="object-contain" />
+            </div>
             <span className="font-[family-name:var(--font-roboto-mono)] text-2xl text-black hidden lg:inline">
               Archestra.AI
             </span>


### PR DESCRIPTION
## What changed
- switched the homepage architecture image from `/api/docs-images/platform-overview-architecture.png` to `/api/docs-images/platform-overview-architecture.webp`

## Why
The docs asset migration removed the old `.png` file, so the homepage was requesting a path that no longer exists and could trigger a hydration mismatch in local dev after hot updates.
