### PR TITLE
Add echo-mcp and go-review-mcp to MCP catalog (#248)

### DIFF
--- a/app/app/mcp-catalog/data/mcp-evaluations/BrunoKrugel__echo-mcp.json
+++ b/app/app/mcp-catalog/data/mcp-evaluations/BrunoKrugel__echo-mcp.json
@@ -1,0 +1,65 @@
+{
+  "name": "BrunoKrugel__echo-mcp",
+  "display_name": "echo-mcp",
+  "description": "MCP wrapper for Echo Framework. Enable AI agents to interact with your Echo API through Model Context Protocol.",
+  "author": {
+    "name": "BrunoKrugel"
+  },
+  "server": {
+    "command": "",
+    "args": [],
+    "env": {},
+    "type": "local"
+  },
+  "tools": [],
+  "prompts": [],
+  "keywords": [],
+  "user_config": {},
+  "readme": "# MCP Wrapper for Echo Framework\n\n[![Build Status](https://github.com/BrunoKrugel/echo-mcp/actions/workflows/run-test.yaml/badge.svg?branch=main)](https://github.com/features/actions)\n[![Codecov branch](https://img.shields.io/codecov/c/github/BrunoKrugel/echo-mcp/main.svg)](https://codecov.io/gh/BrunoKrugel/echo-mcp)\n[![Go Report Card](https://goreportcard.com/badge/github.com/BrunoKrugel/echo-mcp)](https://goreportcard.com/report/github.com/BrunoKrugel/echo-mcp)\n[![Release](https://img.shields.io/github/release/BrunoKrugel/echo-mcp.svg?style=flat-square)](https://github.com/BrunoKrugel/echo-mcp/releases)\n\nWrap any existing Echo API into MCP tools and enable AI agents to interact with your API through [Model Context Protocol](https://modelcontextprotocol.io/introduction).\n\nInspired by [gin-mcp](https://github.com/ckanthony/gin-mcp) but for the [Echo framework](https://echo.labstack.com/).\n\n## Key Features\n\n- **Zero Configuration**: Works with any existing Echo API\n- **Multiple Schema Sources**: Support for Swaggo, raw OpenAPI YAML/JSON, and manual schemas\n- **Filtering**: Include/exclude endpoints with wildcard patterns\n- **MCP Compatible**: Works with any agent that supports MCP.\n\n## Installation\n\n```bash\ngo get github.com/BrunoKrugel/echo-mcp\n```\n\n## Quick Start\n\n```go\npackage main\n\nimport (\n    \"net/http\"\n    server \"github.com/BrunoKrugel/echo-mcp\"\n    \"github.com/labstack/echo/v4\"\n)\n\nfunc main() {\n    e := echo.New()\n\n    // Existing API routes\n    e.GET(\"/ping\", func(c echo.Context) error {\n        return c.JSON(http.StatusOK, map[string]string{\"message\": \"pong\"})\n    })\n\n\n    // Add MCP support\n    mcp := server.New(e)\n    mcp.Mount(\"/mcp\")\n\n    e.Start(\":8080\")\n}\n```\n\nNow the API is accessible at `http://localhost:8080/mcp`\n\n## MCP Client Integration\n\nOnce your server is running:\n\n```json\n{\n  \"mcpServers\": {\n    \"echo-api\": {\n      \"type\": \"http\",\n      \"url\": \"http://localhost:8080/mcp\",\n      \"timeout\": 120\n    }\n  }\n}\n```\n\n## Local Testing\n\nFor local testing, use MCP Inspector:\n\n```bash\nnpx @modelcontextprotocol/inspector http://localhost:8080/mcp\n```\n",
+  "category": "Development",
+  "quality_score": 55,
+  "archestra_config": {
+    "client_config_permutations": {
+      "echo-mcp-http": {
+        "command": "",
+        "args": [],
+        "env": {}
+      }
+    },
+    "oauth": {
+      "provider": null,
+      "required": false
+    },
+    "works_in_archestra": false
+  },
+  "github_info": {
+    "owner": "BrunoKrugel",
+    "repo": "echo-mcp",
+    "url": "https://github.com/BrunoKrugel/echo-mcp",
+    "name": "BrunoKrugel__echo-mcp",
+    "path": null,
+    "stars": 8,
+    "contributors": 2,
+    "issues": 1,
+    "releases": true,
+    "ci_cd": true,
+    "latest_commit_hash": "86756b089c98c8ffc717647f0cee8aeefcc37b34"
+  },
+  "programming_language": "Go",
+  "framework": "Echo",
+  "last_scraped_at": "2026-04-16T13:00:00.000Z",
+  "evaluation_model": "gemini-2.5-flash",
+  "protocol_features": {
+    "implementing_tools": true,
+    "implementing_prompts": false,
+    "implementing_resources": false,
+    "implementing_sampling": false,
+    "implementing_roots": false,
+    "implementing_logging": false,
+    "implementing_stdio": false,
+    "implementing_streamable_http": true,
+    "implementing_oauth2": false
+  },
+  "dependencies": [],
+  "raw_dependencies": ""
+}

--- a/app/app/mcp-catalog/data/mcp-evaluations/BrunoKrugel__go-review-mcp.json
+++ b/app/app/mcp-catalog/data/mcp-evaluations/BrunoKrugel__go-review-mcp.json
@@ -1,0 +1,70 @@
+{
+  "name": "BrunoKrugel__go-review-mcp",
+  "display_name": "go-review-mcp",
+  "description": "A Model Context Protocol (MCP) server that provides real-time access to official Go style guides for intelligent code review.",
+  "author": {
+    "name": "BrunoKrugel"
+  },
+  "server": {
+    "command": "go-review-mcp",
+    "args": [],
+    "env": {},
+    "type": "local"
+  },
+  "tools": [],
+  "prompts": [],
+  "keywords": [],
+  "user_config": {},
+  "readme": "# Go Review MCP\n\nA Model Context Protocol (MCP) server that provides real-time access to official Go style guides for intelligent code review.\n\n## Overview\n\nGo Review MCP fetches the latest style guides directly from official and recommended sources:\n\n### Official\n\n- [Google Go Style Guide](https://google.github.io/styleguide/go/guide)\n- [Google Go Style Decisions](https://google.github.io/styleguide/go/decisions)\n- [Google Go Best Practices](https://google.github.io/styleguide/go/best-practices)\n\n### Recommended\n\n- [Uber Go Style Guide](https://github.com/uber-go/guide/blob/master/style.md)\n\n## Features\n\n### Tools\n\n- **fetch_live_guide** - Fetch and index the latest style guides from all official sources (Google and Uber)\n- **search_live_guide** - Search through all live-fetched guide content for specific patterns\n- **get_guide_topic** - Extract topic-specific content from all live guides (naming, errors, concurrency, testing, interfaces, formatting, comments, imports, context)\n- **get_review_guidelines** - Get curated review guidelines for specific topics\n\n### Prompts\n\n- **review_code** - Comprehensive Go code review\n- **check_naming** - Review naming conventions\n- **check_error_handling** - Review error handling patterns\n- **check_concurrency** - Review concurrency patterns\n- **check_testing** - Review test code quality\n- **check_interfaces** - Review interface design\n\n## Installation\n\n### Using go install\n\n```bash\ngo install github.com/BrunoKrugel/go-review-mcp@latest\n```\n\n## Configuration\n\n### Claude Desktop\n\nAdd to your `claude_desktop_config.json`:\n\n```json\n{\n  \"mcpServers\": {\n    \"go-review\": {\n      \"command\": \"go-review-mcp\",\n      \"args\": []\n    }\n  }\n}\n```\n\n### HTTP Mode (for testing with MCP Inspector)\n\n```bash\ngo-review-mcp --transport http --port 8080\n```\n\n## Requirements\n\n- Go 1.21 or later\n- Internet connection for fetching live guides\n\n## License\n\nMIT License\n",
+  "category": "Development",
+  "quality_score": 55,
+  "archestra_config": {
+    "client_config_permutations": {
+      "go-review-mcp-stdio": {
+        "command": "go-review-mcp",
+        "args": [],
+        "env": {}
+      },
+      "go-review-mcp-http": {
+        "command": "go-review-mcp",
+        "args": ["--transport", "http", "--port", "8080"],
+        "env": {}
+      }
+    },
+    "oauth": {
+      "provider": null,
+      "required": false
+    },
+    "works_in_archestra": false
+  },
+  "github_info": {
+    "owner": "BrunoKrugel",
+    "repo": "go-review-mcp",
+    "url": "https://github.com/BrunoKrugel/go-review-mcp",
+    "name": "BrunoKrugel__go-review-mcp",
+    "path": null,
+    "stars": 2,
+    "contributors": 1,
+    "issues": 1,
+    "releases": true,
+    "ci_cd": false,
+    "latest_commit_hash": "67cff145b407b9cb16f9d705621f8a6c0d87df76"
+  },
+  "programming_language": "Go",
+  "framework": null,
+  "last_scraped_at": "2026-04-16T13:00:00.000Z",
+  "evaluation_model": "gemini-2.5-flash",
+  "protocol_features": {
+    "implementing_tools": true,
+    "implementing_prompts": true,
+    "implementing_resources": false,
+    "implementing_sampling": false,
+    "implementing_roots": false,
+    "implementing_logging": false,
+    "implementing_stdio": true,
+    "implementing_streamable_http": true,
+    "implementing_oauth2": false
+  },
+  "dependencies": [],
+  "raw_dependencies": ""
+}


### PR DESCRIPTION
Closes #248\n\nAdds two MCP server catalog entries by @BrunoKrugel:\n\n1. **echo-mcp** - MCP wrapper for Echo Framework that enables AI agents to interact with Echo APIs through Model Context Protocol. Supports Swaggo, raw OpenAPI schemas, and manual schemas.\n\n2. **go-review-mcp** - MCP server providing real-time access to official Go style guides (Google and Uber) for intelligent code review. Includes 4 tools and 6 prompts.\n\nBoth servers are written in Go.