### PR TITLE
fix: clear HuggingFace oauth_config.scopes to enable discovery

### DIFF
--- a/app/app/mcp-catalog/data/mcp-evaluations/huggingface__remote-mcp.json
+++ b/app/app/mcp-catalog/data/mcp-evaluations/huggingface__remote-mcp.json
@@ -7,7 +7,7 @@
     "server_url": "https://huggingface.co/mcp",
     "client_id": "",
     "redirect_uris": ["http://localhost:8080/oauth/callback"],
-    "scopes": ["read", "write"],
+    "scopes": [],
     "description": "HuggingFace MCP Server (dynamic registration)",
     "default_scopes": ["read", "write"],
     "supports_resource_metadata": true


### PR DESCRIPTION
## Summary
- Set \`oauth_config.scopes\` to \`[]\` for the HuggingFace MCP catalog entry
