### PR TITLE
perf: optimize community-stream DB traffic

### DIFF
--- a/app/app/community-stream/db/cache.ts
+++ b/app/app/community-stream/db/cache.ts
@@ -1,4 +1,4 @@
-import { asc } from 'drizzle-orm';
+import { asc, gt } from 'drizzle-orm';
 
 import { getDb } from './connection';
 import { slackChannels, slackMessages, slackUsers } from './schema';
@@ -18,9 +18,9 @@ interface CacheData {
 }
 
 let cache: CacheData | null = null;
-let refreshTimer: ReturnType<typeof setInterval> | null = null;
+let syncTimer: ReturnType<typeof setInterval> | null = null;
 
-const REFRESH_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+const SYNC_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 
 async function loadFromDb(): Promise<CacheData> {
   const db = getDb();
@@ -57,14 +57,70 @@ async function loadFromDb(): Promise<CacheData> {
   return { channels, users, messagesByChannel, threads, loadedAt: Date.now() };
 }
 
-let syncTimer: ReturnType<typeof setInterval> | null = null;
-const SYNC_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+async function incrementalRefresh(): Promise<void> {
+  if (!cache) {
+    cache = await loadFromDb();
+    return;
+  }
+
+  const db = getDb();
+  const since = new Date(cache.loadedAt);
+
+  const [channels, userRows, updatedMessages] = await Promise.all([
+    db.select().from(slackChannels).orderBy(asc(slackChannels.name)),
+    db.select().from(slackUsers),
+    db.select().from(slackMessages).where(gt(slackMessages.syncedAt, since)).orderBy(asc(slackMessages.createdAt)),
+  ]);
+
+  // Update channels and users (small tables, cheap)
+  cache.channels = channels;
+  const users: Record<string, User> = {};
+  for (const u of userRows) users[u.id] = u;
+  cache.users = users;
+
+  // Re-initialize messagesByChannel keys for any new channels
+  for (const ch of channels) {
+    if (!cache.messagesByChannel[ch.id]) cache.messagesByChannel[ch.id] = [];
+  }
+
+  // Merge only changed messages into existing cache
+  for (const msg of updatedMessages) {
+    if (msg.threadTs) {
+      const key = `${msg.channelId}:${msg.threadTs}`;
+      if (!cache.threads[key]) cache.threads[key] = [];
+      const existing = cache.threads[key];
+      const idx = existing.findIndex((m) => m.id === msg.id);
+      if (idx >= 0) {
+        existing[idx] = msg;
+      } else {
+        // Insert in sorted order by createdAt
+        const insertIdx = existing.findIndex((m) => m.createdAt > msg.createdAt);
+        if (insertIdx === -1) existing.push(msg);
+        else existing.splice(insertIdx, 0, msg);
+      }
+    } else {
+      const channelMsgs = cache.messagesByChannel[msg.channelId] || [];
+      if (!cache.messagesByChannel[msg.channelId]) cache.messagesByChannel[msg.channelId] = channelMsgs;
+      const idx = channelMsgs.findIndex((m) => m.id === msg.id);
+      if (idx >= 0) {
+        channelMsgs[idx] = msg;
+      } else {
+        // Insert in sorted order by createdAt
+        const insertIdx = channelMsgs.findIndex((m) => m.createdAt > msg.createdAt);
+        if (insertIdx === -1) channelMsgs.push(msg);
+        else channelMsgs.splice(insertIdx, 0, msg);
+      }
+    }
+  }
+
+  cache.loadedAt = Date.now();
+}
 
 async function backgroundSync() {
   try {
     const { runSlackSync } = await import('../scripts/slack-sync');
     await runSlackSync();
-    cache = await loadFromDb();
+    await incrementalRefresh();
     console.log('[sync] Background sync + cache refresh done');
   } catch (e) {
     console.error('[sync] Background sync failed:', e);
@@ -74,33 +130,37 @@ async function backgroundSync() {
 async function getCache(): Promise<CacheData> {
   if (!cache) {
     cache = await loadFromDb();
-    if (!refreshTimer) {
-      refreshTimer = setInterval(async () => {
-        try {
-          cache = await loadFromDb();
-        } catch (e) {
-          console.error('Cache refresh failed:', e);
+    if (process.env.SLACK_BOT_TOKEN) {
+      // Start background sync interval (also refreshes cache after sync)
+      if (!syncTimer) {
+        syncTimer = setInterval(backgroundSync, SYNC_INTERVAL_MS);
+        if (syncTimer && typeof syncTimer === 'object' && 'unref' in syncTimer) {
+          syncTimer.unref();
         }
-      }, REFRESH_INTERVAL_MS);
-      if (refreshTimer && typeof refreshTimer === 'object' && 'unref' in refreshTimer) {
-        refreshTimer.unref();
+        // Run first sync after a short delay to not block startup
+        setTimeout(backgroundSync, 10_000);
       }
-    }
-    // Start background sync interval
-    if (!syncTimer && process.env.SLACK_BOT_TOKEN) {
-      syncTimer = setInterval(backgroundSync, SYNC_INTERVAL_MS);
-      if (syncTimer && typeof syncTimer === 'object' && 'unref' in syncTimer) {
-        syncTimer.unref();
+    } else {
+      // No Slack token — just refresh cache from DB periodically
+      if (!syncTimer) {
+        syncTimer = setInterval(async () => {
+          try {
+            await incrementalRefresh();
+          } catch (e) {
+            console.error('Cache refresh failed:', e);
+          }
+        }, SYNC_INTERVAL_MS);
+        if (syncTimer && typeof syncTimer === 'object' && 'unref' in syncTimer) {
+          syncTimer.unref();
+        }
       }
-      // Run first sync after a short delay to not block startup
-      setTimeout(backgroundSync, 10_000);
     }
   }
   return cache;
 }
 
 export async function refreshCache(): Promise<void> {
-  cache = await loadFromDb();
+  await incrementalRefresh();
 }
 
 // --- Cached query helpers ---

--- a/app/app/community-stream/db/connection.ts
+++ b/app/app/community-stream/db/connection.ts
@@ -3,9 +3,13 @@ import { drizzle } from 'drizzle-orm/neon-http';
 
 import * as schema from './schema';
 
+let cachedDb: ReturnType<typeof drizzle<typeof schema>> | null = null;
+
 export function getDb() {
+  if (cachedDb) return cachedDb;
   const databaseUrl = process.env.DATABASE_URL;
   if (!databaseUrl) throw new Error('DATABASE_URL not set');
   const sql = neon(databaseUrl);
-  return drizzle({ client: sql, schema });
+  cachedDb = drizzle({ client: sql, schema });
+  return cachedDb;
 }

--- a/app/app/community-stream/scripts/slack-sync.ts
+++ b/app/app/community-stream/scripts/slack-sync.ts
@@ -1,5 +1,5 @@
 import { WebClient } from '@slack/web-api';
-import { eq } from 'drizzle-orm';
+import { eq, inArray } from 'drizzle-orm';
 
 import { getDb } from '../db/connection';
 import { slackChannels, slackMessages, slackUsers, syncState } from '../db/schema';
@@ -165,7 +165,64 @@ async function syncChannelMessages(
     totalNew += await fetchMessages(slack, db, channelId, {});
   }
 
+  // Re-fetch recent messages (last 30 days) to pick up updated reply counts and new thread replies
+  // for messages that were synced before any replies were added
+  if (state?.newestTs) {
+    const oneMonthAgo = String(Date.now() / 1000 - 30 * 86400);
+    await refreshRecentThreads(slack, db, channelId, oneMonthAgo);
+  }
+
   console.log(`  Synced ${totalNew} new messages for #${channelName}`);
+}
+
+async function refreshRecentThreads(slack: WebClient, db: ReturnType<typeof getDb>, channelId: string, oldest: string) {
+  let cursor: string | undefined;
+
+  do {
+    const result = await slack.conversations.history({
+      channel: channelId,
+      oldest,
+      limit: 200,
+      cursor,
+    });
+
+    const messages = result.messages || [];
+    const threadedMsgs = messages.filter((m) => m.ts && m.reply_count && m.reply_count > 0);
+
+    if (threadedMsgs.length > 0) {
+      // Batch-read existing reply counts to skip unchanged threads
+      const ids = threadedMsgs.map((m) => makeMessageId(channelId, m.ts!));
+      const existingRows = await db
+        .select({ id: slackMessages.id, replyCount: slackMessages.replyCount })
+        .from(slackMessages)
+        .where(inArray(slackMessages.id, ids));
+      const existingMap = new Map(existingRows.map((r) => [r.id, r.replyCount]));
+
+      for (const msg of threadedMsgs) {
+        const id = makeMessageId(channelId, msg.ts!);
+        const existingCount = existingMap.get(id);
+
+        // Skip if reply count hasn't changed
+        if (existingCount === msg.reply_count) continue;
+
+        // Update the parent message's reply count
+        await db
+          .update(slackMessages)
+          .set({
+            replyCount: msg.reply_count!,
+            replyUsersCount: msg.reply_users_count || 0,
+            syncedAt: new Date(),
+          })
+          .where(eq(slackMessages.id, id));
+
+        // Fetch thread replies (upserts, so safe to re-run)
+        await fetchThreadReplies(slack, db, channelId, msg.ts!);
+      }
+    }
+
+    cursor = result.response_metadata?.next_cursor || undefined;
+    if (cursor) await sleep(500);
+  } while (cursor);
 }
 
 async function fetchMessages(


### PR DESCRIPTION
- Singleton DB connection (reuse Neon HTTP client across calls)
- Incremental cache refresh (only fetch rows with syncedAt > last load)
- Remove duplicate refresh timer (sync timer already refreshes)
- Skip unchanged threads in refreshRecentThreads (compare reply_count before fetching)