### PR TITLE
[codex] fix community calls redirect

### DIFF
--- a/app/next.config.mjs
+++ b/app/next.config.mjs
@@ -72,6 +72,16 @@ const nextConfig = {
   },
   async redirects() {
     return [
+      {
+        source: '/community-calls',
+        destination: '/community-stream',
+        permanent: true,
+      },
+      {
+        source: '/community-calls/:path*',
+        destination: '/community-stream/:path*',
+        permanent: true,
+      },
       /**
        * Address some typos we have in the platform docs URLs
        */


### PR DESCRIPTION
## Summary

Adds permanent redirects for the legacy `/community-calls` URL so users no longer hit a 404.

## Root cause

The site has a community experience at `/community-stream`, but no route or redirect existed for `/community-calls`, so shared or indexed links to that page returned 404.

## Impact

Requests to `/community-calls` now redirect to `/community-stream`, and nested `/community-calls/...` links map to the corresponding `/community-stream/...` path.

## Validation

- `pnpm install`
- `pnpm typecheck`
- `pnpm build`